### PR TITLE
Improves the result factory

### DIFF
--- a/src/GAAPICommon.Core/GenericServiceCallResultFactory.cs
+++ b/src/GAAPICommon.Core/GenericServiceCallResultFactory.cs
@@ -33,14 +33,22 @@ namespace GAAPICommon.Core
 
         public static ServiceCallResultDto<T> FromError(int serviceCode)
         {
-            if (serviceCode < 10) throw new ArgumentOutOfRangeException("Service code must be >= 10");
+            if (serviceCode < 10) 
+                throw new ArgumentOutOfRangeException("Service code must be >= 10");
 
             return new ServiceCallResultDto<T>(serviceCode, default, null);
         }
 
+        public static ServiceCallResultDto<T> FromError<U>(U value) where U : Enum
+        {
+            int serviceCode = Convert.ToInt32(value);
+            return ServiceCallResultFactory<T>.FromError(serviceCode);
+        }
+       
         public static ServiceCallResultDto<T> FromCaughtException(int serviceCode, Exception ex)
         {
-            if (serviceCode < 10) throw new ArgumentOutOfRangeException("Service code must be >= 10");
+            if (serviceCode < 10) 
+                throw new ArgumentOutOfRangeException("Service code must be >= 10");
 
             return new ServiceCallResultDto<T>(serviceCode, default, ex);
         }

--- a/src/GAAPICommon.Core/ServiceCallResultFactory.cs
+++ b/src/GAAPICommon.Core/ServiceCallResultFactory.cs
@@ -33,9 +33,16 @@ namespace GAAPICommon.Core
 
         public static ServiceCallResultDto FromError(int serviceCode)
         {
-            if (serviceCode < 10) throw new ArgumentOutOfRangeException("Service code must be >= 10");
+            if (serviceCode < 10) 
+                throw new ArgumentOutOfRangeException("Service code must be >= 10");
 
             return new ServiceCallResultDto(serviceCode, null);
+        }
+
+        public static ServiceCallResultDto FromError<T>(T value) where T : System.Enum
+        {
+            int serviceCode = Convert.ToInt32(value);
+            return FromError(serviceCode);
         }
 
         public static ServiceCallResultDto FromCaughtException(int serviceCode, Exception ex)

--- a/tests/GAAPICommon.Core.Test/Enumerators.cs
+++ b/tests/GAAPICommon.Core.Test/Enumerators.cs
@@ -1,0 +1,16 @@
+﻿namespace GAAPICommon.Core.Test
+{
+    public enum VideoGraves
+    {
+        NES = 10,
+        SNES = 11,
+        Genesis = 12,
+        Dreamcast = 13,
+        Playstation = 14,
+        N64 = 15,
+        Saturn = 16,
+        Nomad = 17,
+        Gameboy = 18,
+        Wonderswan = 19
+    }
+}

--- a/tests/GAAPICommon.Core.Test/GAAPICommon.Core.Test.csproj
+++ b/tests/GAAPICommon.Core.Test/GAAPICommon.Core.Test.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Enumerators.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TServiceCallResultDto.cs" />
     <Compile Include="TServiceCallResultFactory.cs" />

--- a/tests/GAAPICommon.Core.Test/TServiceCallResultFactory.cs
+++ b/tests/GAAPICommon.Core.Test/TServiceCallResultFactory.cs
@@ -8,6 +8,27 @@ namespace GAAPICommon.Core.Test
     [TestFixture]
     public class TServiceCallResultFactory
     {
+        [TestCase(VideoGraves.Wonderswan)]
+        public void FromGenericEnum(VideoGraves videoGraves)
+        {
+            ServiceCallResultDto result = ServiceCallResultFactory.FromError(videoGraves);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual((int)videoGraves, result.ServiceCode);
+        }
+
+        [TestCase(VideoGraves.Wonderswan)]
+        public void FromGenericEnumWithValue(VideoGraves videoGraves)
+        {
+            ServiceCallResultFactory<string>.FromError(videoGraves);
+            ServiceCallResultDto<string> result = ServiceCallResultFactory<string>.FromError(videoGraves);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual((int)videoGraves, result.ServiceCode);
+            Assert.AreEqual(default(string), result.Value);
+        }
+
+
         [Test]
         public void FromCaughtException()
         {


### PR DESCRIPTION
Result factory can now take a generic enum as a factory method for service code errors