### PR TITLE
Enable .NET Core Fleet State clients

### DIFF
--- a/src/GAAPICommon.Architecture/IKingpinStateCore.cs
+++ b/src/GAAPICommon.Architecture/IKingpinStateCore.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GAAPICommon.Architecture
+{
+    public interface IKingpinStateCore : IKingpinStatusReporter
+    {
+        string Alias { get; }
+
+        bool IsVirtual { get; }
+
+        byte Tick { get; }
+
+        float X { get; }
+
+        float Y { get; }
+
+        float Heading { get; }
+
+        MovementType CurrentMovementType { get; }
+
+        long IPAddress { get; }
+
+        byte[] StateCastExtendedData { get; }
+
+        double Speed { get; }
+
+        int WaypointLastId { get; }
+
+        int WaypointNextId { get; }
+
+        AgvMode AgvMode { get; }
+
+        double BatteryChargePercentage { get; }
+
+        ExtendedDataFaultStatus ExtendedDataFaultStatus { get; }
+
+        FrozenState FrozenState { get; }
+
+        bool IsCharging { get; }
+
+        int LastCompletedInstructionId { get; }
+
+        TimeSpan Stationary { get; }
+
+        byte[] CurrentWaypointExtendedData { get; }
+    }
+}

--- a/src/GAAPICommon.Core/Dtos/FleetStateCoreDto.cs
+++ b/src/GAAPICommon.Core/Dtos/FleetStateCoreDto.cs
@@ -1,0 +1,30 @@
+﻿using GAAPICommon.Architecture;
+using System.Linq;
+using System.Runtime.Serialization;
+
+namespace GAAPICommon.Core.Dtos
+{
+    [DataContract]
+    public class FleetStateCoreDto
+    {
+        public FleetStateCoreDto()
+        {
+        }
+
+        public FleetStateCoreDto(byte tick, IKingpinStateCore[] kingpinStatesCore, FrozenState frozenState)
+        {
+            Tick = tick;
+            KingpinStates = kingpinStatesCore.Cast<KingpinStateCoreDto>().ToArray();
+            FrozenState = frozenState;
+        }
+
+        [DataMember]
+        public KingpinStateCoreDto[] KingpinStates { get; set; } // Needs to be concrete for serialization
+ 
+        [DataMember]
+        public byte Tick { get; set; }
+
+        [DataMember]
+        public FrozenState FrozenState { get; set; }
+    }
+}

--- a/src/GAAPICommon.Core/Dtos/KingpinStateCoreDto.cs
+++ b/src/GAAPICommon.Core/Dtos/KingpinStateCoreDto.cs
@@ -1,0 +1,84 @@
+﻿using GAAPICommon.Architecture;
+using Newtonsoft.Json;
+using System;
+using System.Net;
+using System.Runtime.Serialization;
+
+namespace GAAPICommon.Core.Dtos
+{
+    /// <summary>
+    /// Serializable structure to represent the 'player' data of a kingpin.
+    /// </summary>
+    [DataContract]
+    public class KingpinStateCoreDto : IKingpinStateCore
+    {
+        [DataMember]
+        public string Alias { get; set; } = string.Empty;
+
+        [DataMember]
+        public bool IsVirtual { get; set; } = false;
+
+        [DataMember]
+        public MovementType CurrentMovementType { get; set; } = MovementType.Stationary;
+
+        [DataMember]
+        public byte Tick { get; set; } = 0;
+
+        [DataMember]
+        public AgvMode AgvMode { get; set; } = AgvMode.Manual;
+
+        [DataMember]
+        public double BatteryChargePercentage { get; set; } = 0.5f;
+
+        [DataMember]
+        public PositionControlStatus PositionControlStatus { get; set; } = PositionControlStatus.OK;
+
+        [DataMember]
+        public NavigationStatus NavigationStatus { get; set; } = NavigationStatus.OK;
+
+        [DataMember]
+        public DynamicLimiterStatus DynamicLimiterStatus { get; set; } = DynamicLimiterStatus.OK;
+
+        [DataMember]
+        public ExtendedDataFaultStatus ExtendedDataFaultStatus { get; set; } = ExtendedDataFaultStatus.OK;
+
+        [DataMember]
+        public FrozenState FrozenState { get; set; }
+
+        [DataMember]
+        public float Heading { get; set; } = float.NaN;
+
+        [DataMember]
+        public long IPAddress { get; set; }
+
+        [DataMember]
+        public bool IsCharging { get; set; } = false;
+
+        [DataMember]
+        public int LastCompletedInstructionId { get; set; } = int.MinValue;
+
+        [DataMember]
+        public double Speed { get; set; } = double.NaN;
+
+        [DataMember]
+        public byte[] StateCastExtendedData { get; set; } = new byte[0];
+
+        [DataMember]
+        public byte[] CurrentWaypointExtendedData { get; set; } = new byte[0];
+
+        [DataMember]
+        public TimeSpan Stationary { get; set; } = TimeSpan.MinValue;
+
+        [DataMember]
+        public int WaypointLastId { get; set; } = int.MinValue;
+
+        [DataMember]
+        public int WaypointNextId { get; set; } = int.MinValue;
+
+        [DataMember]
+        public float X { get; set; } = float.NaN;
+
+        [DataMember]
+        public float Y { get; set; } = float.NaN;
+    }
+}


### PR DESCRIPTION
Provide a dedicated interface and DTOs so that .NET Core clients can receive Fleet State update events unimpeded.