### PR TITLE
AI-1096 Add IsChanged property to ISpotManagerState

### DIFF
--- a/src/GAAPICommon.Architecture/ISpotManagerState.cs
+++ b/src/GAAPICommon.Architecture/ISpotManagerState.cs
@@ -8,6 +8,8 @@ namespace GAAPICommon.Architecture
 
         IEnumerable<IParkingSpotState> ParkingSpotStates { get; }
 
+        bool IsChanged { get; }
+
         byte Tick { get; }
     }
 }

--- a/src/GAAPICommon.Core/Dtos/AgentDto.cs
+++ b/src/GAAPICommon.Core/Dtos/AgentDto.cs
@@ -5,6 +5,7 @@ using System.Runtime.Serialization;
 
 namespace GAAPICommon.Core.Dtos
 {
+	[DataContract]
 	public enum AgentMarkovState
 	{
 		[EnumMember]

--- a/src/GAAPICommon.Core/Dtos/SpotManagerStateDto.cs
+++ b/src/GAAPICommon.Core/Dtos/SpotManagerStateDto.cs
@@ -12,11 +12,14 @@ namespace GAAPICommon.Core.Dtos
         public IEnumerable<ChargingSpotStateDto> ChargingSpotStateDtos { get; set; } = Enumerable.Empty<ChargingSpotStateDto>();
 
         [DataMember]
-        public IEnumerable<ParkingSpotStateDto> ParkingSpotStateDtos { get; set;  } = Enumerable.Empty<ParkingSpotStateDto>();
+        public IEnumerable<ParkingSpotStateDto> ParkingSpotStateDtos { get; set; } = Enumerable.Empty<ParkingSpotStateDto>();
 
         public IEnumerable<IChargingSpotState> ChargingSpotStates => ChargingSpotStateDtos;
 
         public IEnumerable<IParkingSpotState> ParkingSpotStates => ParkingSpotStateDtos;
+
+        [DataMember]
+        public bool IsChanged { get; set; } = false;
 
         [DataMember]
         public byte Tick { get; set; }


### PR DESCRIPTION
Preparing to allow SchedulingClients to receive callbacks when SpotManager enabled/disabled changes or bookings change. 

The addition of the missing [DataContract] to AgentDto.cs is unrelated but syncs devel branch with master branch which already contains [DataContract] via an earlier pull request from a branch other than devel.